### PR TITLE
マッチング事故が負けた時しか設定できないのをやめる

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
               </li>
               <li class="input-item fs-s">
                 <label>
-                  <input type="checkbox" v-model="modMissmatch" v-attr="disabled: isResultWin">マッチング事故
+                  <input type="checkbox" v-model="modMissmatch" v-attr="disabled: isDisconnected">マッチング事故
                 </label>
                 <label>
                   <input type="checkbox" v-model="modTagmatch">タッグマッチ
@@ -227,7 +227,7 @@
           </li>
           <li class="input-item">
             <label>
-              <input type="checkbox" v-model="missmatch" v-attr="disabled: isResultWin">マッチング事故
+              <input type="checkbox" v-model="missmatch" v-attr="disabled: isDisconnected">マッチング事故
             </label>
             <label>
               <input type="checkbox" v-model="tagmatch">タッグマッチ

--- a/src/script/const.js
+++ b/src/script/const.js
@@ -9,6 +9,14 @@ module.exports = {
     5: '回線落ち'
   },
 
+  RESULT_STR: {
+    // WIN:     1,
+    // LOSE:    2,
+    // KO_WIN:  3,
+    // KO_LOSE: 4,
+    DISCONNECTED:  5
+  },
+
   RULE: {
     1: 'エリア',
     2: 'ヤグラ',

--- a/src/script/view/input-view.js
+++ b/src/script/view/input-view.js
@@ -26,9 +26,8 @@ module.exports = {
     showSetReaction: false
   },
   computed: {
-    isResultWin: function() {
-      let isWin = (this.result|0) % 2;
-      return !!isWin;
+    isDisconnected: function() {
+      return (this.result|0) === Const.RESULT_STR.DISCONNECTED;
     },
     canSet: function() {
       return Util.canInput(this.rateScore);

--- a/src/script/view/list-view.js
+++ b/src/script/view/list-view.js
@@ -29,9 +29,8 @@ module.exports = {
     rates:   Util.objToOptionsArr(Const.RATE_TABLE, 'REVERSE'),
   },
   computed: {
-    isResultWin: function() {
-      let isWin = (this.modResult|0) % 2;
-      return !!isWin;
+    isDisconnected: function() {
+      return (this.modResult|0) === Const.RESULT_STR.DISCONNECTED;
     },
     canSet: function() {
       return Util.canInput(this.modRateScore);


### PR DESCRIPTION
:ok_hand: 
